### PR TITLE
Create compat - missing Forge condition 

### DIFF
--- a/src/main/resources/data/homespun/recipes/compat/create/ironwood_planks_from_cutting.json
+++ b/src/main/resources/data/homespun/recipes/compat/create/ironwood_planks_from_cutting.json
@@ -12,4 +12,11 @@
     }
   ],
   "processingTime": 50
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/src/main/resources/data/homespun/recipes/compat/create/olive_planks_from_cutting.json
+++ b/src/main/resources/data/homespun/recipes/compat/create/olive_planks_from_cutting.json
@@ -11,5 +11,11 @@
       "count": 6
     }
   ],
-  "processingTime": 50
+  "processingTime": 50,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/src/main/resources/data/homespun/recipes/compat/create/stripped_ironwood_log_from_cutting.json
+++ b/src/main/resources/data/homespun/recipes/compat/create/stripped_ironwood_log_from_cutting.json
@@ -10,5 +10,11 @@
       "item": "homespun:stripped_ironwood_log"
     }
   ],
-  "processingTime": 50
+  "processingTime": 50,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/src/main/resources/data/homespun/recipes/compat/create/stripped_ironwood_wood_from_cutting.json
+++ b/src/main/resources/data/homespun/recipes/compat/create/stripped_ironwood_wood_from_cutting.json
@@ -10,5 +10,11 @@
       "item": "homespun:stripped_ironwood_wood"
     }
   ],
-  "processingTime": 50
+  "processingTime": 50,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/src/main/resources/data/homespun/recipes/compat/create/stripped_olive_log_from_cutting.json
+++ b/src/main/resources/data/homespun/recipes/compat/create/stripped_olive_log_from_cutting.json
@@ -10,5 +10,11 @@
       "item": "homespun:stripped_olive_log"
     }
   ],
-  "processingTime": 50
+  "processingTime": 50  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/src/main/resources/data/homespun/recipes/compat/create/stripped_olive_wood_from_cutting.json
+++ b/src/main/resources/data/homespun/recipes/compat/create/stripped_olive_wood_from_cutting.json
@@ -10,5 +10,11 @@
       "item": "homespun:stripped_olive_wood"
     }
   ],
-  "processingTime": 50
+  "processingTime": 50  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }


### PR DESCRIPTION
When loaded on console spam "unable parsing" (by kubejs) because there are some wrong recipes that still missing type
Adding a condition that only show when create was installed will be fix them